### PR TITLE
Make temporary XDG_CACHE_HOME for each worker.

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -19,6 +19,7 @@
 
 #include <nix/value-to-json.hh>
 
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/resource.h>
@@ -299,6 +300,9 @@ int main(int argc, char * * argv)
                              from{std::make_shared<AutoCloseFD>(std::move(toPipe.readSide))}
                             ]()
                             {
+                                auto tmpdir = createTempDir("", "nix-eval-jobs", true, true, S_IRWXU);
+                                setenv("XDG_CACHE_HOME", tmpdir.c_str(), 1);
+
                                 try {
                                     EvalState state(myArgs.searchPath, openStore());
                                     Bindings & autoArgs = *myArgs.getAutoArgs(state);


### PR DESCRIPTION
This is to prevent thread-unsafe git actions in XDG_CACHE_HOME. There
exists in $XDG_CACHE_HOME/nix a git repository which is a shared
resource. Since nix-eval-jobs' worker processes all start up around
the same time, they are prone to encountering git errors when they
create this repository.