### PR TITLE
(backport) Fix hang when downloading.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -32,4 +32,7 @@
 
   ];
 
+  shellHook = ''
+    export NIX_DEBUG_INFO_DIRS="${pkgs.curl.debug}/lib/debug:${pkgs.nix.debug}/lib/debug''${NIX_DEBUG_INFO_DIRS:+:$NIX_DEBUG_INFO_DIRS}"
+  '';
 })

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -381,7 +381,11 @@ int main(int argc, char * * argv)
             }
         };
 
-        /* Collect initial attributes to evaluate */
+        /* Collect initial attributes to evaluate. This must be done
+           in a separate fork to avoid spawning a download in the
+           parent process. If that happens, worker processes will try
+           to enqueue downloads on their own download threads (which
+           will not exist). */
         {
             AutoCloseFD from, to;
             Pipe toPipe, fromPipe;

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -395,41 +395,33 @@ int main(int argc, char * * argv)
                 {
                     debug("created initial attribute collection process %d", getpid());
 
+                    nlohmann::json reply;
+
                     try {
                         EvalState state(myArgs.searchPath, openStore());
                         Bindings & autoArgs = *myArgs.getAutoArgs(state);
 
                         auto vRoot = releaseExprTopLevelValue(state, autoArgs);
 
-                        if (vRoot->type != tAttrs)
-                            throw TypeError("top level value is a '%s', expected an attribute set", showType(*vRoot));
+                        if (vRoot->type != tAttrs) {
+                            std::stringstream ss;
+                            ss << "top level value is '" << showType(*vRoot) << "', expected an attribute set";
 
-                        nlohmann::json reply;
-
-                        try {
+                            reply["error"] = ss.str();
+                        } else {
                             std::vector<std::string> attrs;
                             for (auto & a : vRoot->attrs->lexicographicOrder())
                                 attrs.push_back(a->name);
 
-
                             reply["attrs"] = attrs;
-
-                            writeLine(to->get(), reply.dump());
-
-                        } catch (EvalError & e) {
-                            reply["error"] = filterANSIEscapes(e.msg(), true);
-                            printError(e.msg());
-
                         }
-                        writeLine(to->get(), reply.dump());
-
                     } catch (Error & e) {
-                        nlohmann::json err;
                         auto msg = e.msg();
-                        err["error"] = filterANSIEscapes(msg, true);
+                        reply["error"] = filterANSIEscapes(msg, true);
                         printError(msg);
-                        writeLine(to->get(), err.dump());
                     }
+
+                    writeLine(to->get(), reply.dump());
                 },
                 ProcessOptions { .allowVfork = false });
             from = std::move(fromPipe.readSide);

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -294,10 +294,10 @@ int main(int argc, char * * argv)
         auto handler = [&]()
         {
             try {
+                std::optional<Pid> pid;
                 AutoCloseFD from, to;
 
                 while (true) {
-                    std::optional<Pid> pid;
 
                     /* Start a new worker process if necessary. */
                     if (!pid.has_value()) {

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -381,16 +381,75 @@ int main(int argc, char * * argv)
             }
         };
 
-        EvalState initialState(myArgs.searchPath, openStore());
-        Bindings & autoArgs = *myArgs.getAutoArgs(initialState);
+        /* Collect initial attributes to evaluate */
+        {
+            AutoCloseFD from, to;
+            Pipe toPipe, fromPipe;
+            toPipe.create();
+            fromPipe.create();
+            Pid p = startProcess(
+                [&,
+                 to{std::make_shared<AutoCloseFD>(std::move(fromPipe.writeSide))},
+                 from{std::make_shared<AutoCloseFD>(std::move(toPipe.readSide))}
+                ]()
+                {
+                    debug("created initial attribute collection process %d", getpid());
 
-        auto topLevelValue = releaseExprTopLevelValue(initialState, autoArgs);
+                    try {
+                        EvalState state(myArgs.searchPath, openStore());
+                        Bindings & autoArgs = *myArgs.getAutoArgs(state);
 
-        if (topLevelValue->type == tAttrs) {
-          auto state(state_.lock());
-          for (auto & a : topLevelValue->attrs->lexicographicOrder()) {
-            state->todo.insert(a->name);
-          }
+                        auto vRoot = releaseExprTopLevelValue(state, autoArgs);
+
+                        if (vRoot->type != tAttrs)
+                            throw TypeError("top level value is a '%s', expected an attribute set", showType(*vRoot));
+
+                        nlohmann::json reply;
+
+                        try {
+                            std::vector<std::string> attrs;
+                            for (auto & a : vRoot->attrs->lexicographicOrder())
+                                attrs.push_back(a->name);
+
+
+                            reply["attrs"] = attrs;
+
+                            writeLine(to->get(), reply.dump());
+
+                        } catch (EvalError & e) {
+                            reply["error"] = filterANSIEscapes(e.msg(), true);
+                            printError(e.msg());
+
+                        }
+                        writeLine(to->get(), reply.dump());
+
+                    } catch (Error & e) {
+                        nlohmann::json err;
+                        auto msg = e.msg();
+                        err["error"] = filterANSIEscapes(msg, true);
+                        printError(msg);
+                        writeLine(to->get(), err.dump());
+                    }
+                },
+                ProcessOptions { .allowVfork = false });
+            from = std::move(fromPipe.readSide);
+            to = std::move(toPipe.writeSide);
+
+            auto s = readLine(from.get());
+            auto json = nlohmann::json::parse(s);
+
+            if (json.find("error") != json.end()) {
+                throw Error("getting initial attributes: %s", (std::string) json["error"]);
+
+            } else if (json.find("attrs") != json.end()) {
+                auto state(state_.lock());
+                for (std::string a : json["attrs"])
+                    state->todo.insert(a);
+
+            } else {
+                throw Error("expected object with \"error\" or \"attrs\", got: %s", s);
+
+            }
         }
 
         std::vector<std::thread> threads;

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -310,9 +310,6 @@ int main(int argc, char * * argv)
                              from{std::make_shared<AutoCloseFD>(std::move(toPipe.readSide))}
                             ]()
                             {
-                                auto tmpdir = createTempDir("", "nix-eval-jobs", true, true, S_IRWXU);
-                                setenv("XDG_CACHE_HOME", tmpdir.c_str(), 1);
-
                                 debug("created worker process %d", getpid());
                                 try {
                                     EvalState state(myArgs.searchPath, openStore());


### PR DESCRIPTION
In #1 I introduced some nix evaluation in the parent process. This could spawn a download thread. If the download thread was spawned, worker threads would not be able to enqueue downloads.  Because we are `fork`ing, each worker thread would have its own address space. Hence, it would try to enqueue a download on its own download thread, which only ever existed in the parent process' address space (thanks to the `std::once_flag` in the `CurlDownloader`'s constructor).

The solution here is to `fork` a process to initially collect all the attributes of the top level attribute set.  Additionally, an `XDG_CACHE_HOME` cannot be made per fork anymore, as the locks on tarball downloads are required for coordination.

There are also a couple minor cleanups here.
1. Add debug symbols to shell.nix
2. Kill zombie processes when they are done.